### PR TITLE
Adding a key for the pr build #

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # [sbt-travisci][] [![travis-badge][]](https://travis-ci.org/dwijnand/sbt-travisci)
 
 `sbt-travisci` is an [sbt](http://www.scala-sbt.org/) plugin to integrate with Travis CI.
@@ -23,6 +24,8 @@ Other than that, as `sbt-travisci` is an AutoPlugin that is all that is required
 
 - `isTravisBuild in Global` will be automatically be set to `true` if the current build is running under Travis
     CI.
+- `travisPrNumber in Global` will be automatically set to the number of the pull request, in case the build is a pull request build. 
+		Otherwise, it will have a value of `None` 
 - `crossScalaVersions in ThisBuild` will be automatically set to the scala versions in `.travis.yml`, falling
     back (with warnings) to the value of `crossScalaVersions in Global` if it can't be found or parsed properly.
 - `scalaVersion in ThisBuild` will be automatically set to `TRAVIS_SCALA_VERSION` if `isTravisBuild` is true,

--- a/notes/1.1.0.markdown
+++ b/notes/1.1.0.markdown
@@ -1,0 +1,2 @@
+- `travisPrNumber in Global` will be automatically set to the number of the pull request, in case the build is a pull request build. 
+		Otherwise, it will have a value of `None`

--- a/src/main/scala/sbttravisci/TravisCiPlugin.scala
+++ b/src/main/scala/sbttravisci/TravisCiPlugin.scala
@@ -1,11 +1,15 @@
 package sbttravisci
 
-import sbt._, Keys._
+import sbt._
+import Keys._
+
+import scala.util.Try
 
 object TravisCiPlugin extends AutoPlugin {
 
   object autoImport {
     val isTravisBuild = settingKey[Boolean]("Flag indicating whether the current build is running under Travis")
+    val prBuildNumber = settingKey[Option[Int]]("Number of the PR, if the build is a pull request build. Empty otherwise")
   }
 
   import autoImport._
@@ -14,7 +18,11 @@ object TravisCiPlugin extends AutoPlugin {
   override def trigger  = allRequirements
 
   override def globalSettings = Seq(
-    isTravisBuild := sys.env.get("TRAVIS").isDefined)
+    isTravisBuild := sys.env.get("TRAVIS").isDefined,
+    prBuildNumber := Try {
+      sys.env.get("TRAVIS_PULL_REQUEST") map (_.toInt)
+    } getOrElse None
+  )
 
   override def buildSettings = Seq(
     scalaVersion := {

--- a/src/main/scala/sbttravisci/TravisCiPlugin.scala
+++ b/src/main/scala/sbttravisci/TravisCiPlugin.scala
@@ -9,7 +9,7 @@ object TravisCiPlugin extends AutoPlugin {
 
   object autoImport {
     val isTravisBuild = settingKey[Boolean]("Flag indicating whether the current build is running under Travis")
-    val prBuildNumber = settingKey[Option[Int]]("Number of the PR, if the build is a pull request build. Empty otherwise")
+    val travisPrNumber = settingKey[Option[Int]]("Number of the PR, if the build is a pull request build. Empty otherwise")
   }
 
   import autoImport._
@@ -19,7 +19,7 @@ object TravisCiPlugin extends AutoPlugin {
 
   override def globalSettings = Seq(
     isTravisBuild := sys.env.get("TRAVIS").isDefined,
-    prBuildNumber := Try {
+    travisPrNumber := Try {
       sys.env.get("TRAVIS_PULL_REQUEST") map (_.toInt)
     } getOrElse None
   )


### PR DESCRIPTION
Adding a task key that allows to determine of the build is a pr build and what is its number. Allows PR builds to be handled differently.